### PR TITLE
[SCC-4752] BibService stress test for GET api

### DIFF
--- a/bib-service/README.md
+++ b/bib-service/README.md
@@ -1,0 +1,19 @@
+# Stress Testing the BibService API
+
+1. Get an ACCESS_TOKEN by following the steps [in main README](../README.md#bearer-tokens).
+
+2. Generate request paths CSV:
+
+```
+ACCESS_TOKEN=<token> ./generate-api-paths.sh https://qa-platform.nypl.org paths.csv 1000
+```
+
+This will create a CSV called `./paths.csv` with 1000 randomized valid (non-404) bib service paths.
+
+2. Run Jmeter:
+
+`./run.sh bib-service ./paths.csv`
+
+Report will launch in a browser on completion (or when you ctrl-c the test).
+
+A shareable zip will also be created that includes the report and raw log file. See command output for details.

--- a/bib-service/generate-api-paths.sh
+++ b/bib-service/generate-api-paths.sh
@@ -52,6 +52,6 @@ while [ $COUNT -lt $TOTAL ]; do
   sleep 3
 done
 
-TRIMMED_CSV=$(cat "$CSV" | head -$LIMIT)
+TRIMMED_CSV=$(cat "$CSV" | head -$TOTAL)
 
 echo "$TRIMMED_CSV" >"$CSV"

--- a/bib-service/generate-api-paths.sh
+++ b/bib-service/generate-api-paths.sh
@@ -1,0 +1,57 @@
+if [ -z "$ACCESS_TOKEN" ]; then
+  echo "No value found for \$ACCESS_TOKEN. Run with ACCESS_TOKEN=x ./generate-api-paths.sh \$URL \$CSV"
+  exit 1
+fi
+
+if [ -z "$1" ]; then
+  echo "Provide a URL to call for getting a list of bib ids."
+  exit 1
+fi
+
+if [ -z "$2" ]; then
+  echo "Provide the name of a CSV output file."
+  exit 1
+fi
+
+if [ -z "$3" ]; then
+  echo "Provide a total number of paths you'd like to generate."
+  exit 1
+fi
+
+BASE_URL="$1"
+CSV="$2"
+TOTAL="$3"
+
+COUNT=0
+LIMIT=100
+
+# start at a random position in the bib catalog
+OFFSET=$RANDOM
+
+echo "PATHS" >"$CSV" # first line in the csv file will be ignored by jmeter
+
+while [ $COUNT -lt $TOTAL ]; do
+  BIBS=$(curl -s -X 'GET' \
+    $BASE_URL'/api/v0.1/bibs?offset='$OFFSET'&limit='$LIMIT'&deleted=false' \
+    -H 'accept: application/json' \
+    -H 'authorization: Bearer '$ACCESS_TOKEN)
+
+  # go to a random offset in the bib catalog
+  OFFSET=$RANDOM
+
+  echo $BIBS | jq -r '.data[] | "/api/v0.1/bibs/\(.nyplSource)/\(.id)"' 2>/dev/null | tee -a "$CSV"
+
+  # Include id and controlNumber searches as possible paths
+  echo $BIBS | jq -r '.data[] | "/api/v0.1/bibs?id=\(.id)"' 2>/dev/null | tee -a "$CSV"
+  echo $BIBS | jq -r '.data[] | "/api/v0.1/bibs?controlNumber=\(.controlNumber)"' 2>/dev/null | grep -v "=$" | tee -a "$CSV"
+
+  COUNT=$(cat "$CSV" | wc -l)
+
+  echo
+  echo "Current count is ["$COUNT"/"$TOTAL"]. Sleeping for 3 seconds..."
+  sleep 3
+done
+
+TRIMMED_CSV=$(cat "$CSV" | head -$LIMIT)
+
+echo "$TRIMMED_CSV" >"$CSV"

--- a/bib-service/run.sh
+++ b/bib-service/run.sh
@@ -1,0 +1,45 @@
+# Usage
+# ./run.sh ENVNAME
+#
+# ENVNAME may be anything; It's just used to name the log file and final report.
+# Examples: "qa" or "qa-new-deployment"
+#
+# e.g.
+# ./run.sh production
+
+TIMESTAMP=$(date +"%Y%m%d%H%M")
+ENVNAME=$1
+CSV=$2
+TOKEN=$3
+LOGFILE=$ENVNAME-TIMESTAMP.jtl
+REPORT=$ENVNAME-$TIMESTAMP
+
+if [ -z $ENVNAME ]; then
+  echo Usage: ./run.sh ENVNAME
+  exit
+fi
+
+mkdir -f runs
+
+echo Running $ENVNAME jmeter test. Logging to ./runs/$LOGFILE
+HEAP="-Xms1g -Xmx1g -XX:MaxMetaspaceSize=256m" jmeter \
+  -t ../generic-api-jmeter-test-plan.jmx \
+  -n \
+  -l ./runs/$LOGFILE \
+  -Jusers=10 \
+  -Jduration=10 \
+  -Jcsv=$CSV \
+  -Jtoken=$TOKEN \
+  -Jdomain=qa-platform.nypl.org
+
+echo Finished. Logs are at runs/$LOGFILE
+
+jmeter -g ./runs/$LOGFILE -o runs/$REPORT
+echo Wrote report to ./runs/$REPORT
+
+cd runs
+zip -rq $ENVNAME-$TIMESTAMP.zip $LOGFILE $REPORT
+cd -
+echo Sharable zip of log and report: runs/$ENVNAME-$TIMESTAMP.zip
+
+open runs/$REPORT/index.html


### PR DESCRIPTION
* For https://newyorkpubliclibrary.atlassian.net/browse/SCC-4752 - this adds support for stress-testing BibService GET endpoints (single bib and search by id/control number)
* Ran it pointed at QA, which is BibService V2. We'll want to flip API Gateway, increase the time of this test run to 10 minutes and diff between V1 and V2.